### PR TITLE
Set up app for Heroku deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem "heroku-deflater", group: :production
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.4)
     minitest (5.20.0)
     msgpack (1.7.2)
     net-imap (0.3.7)
@@ -132,6 +133,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
@@ -275,6 +279,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    heroku-deflater (0.6.3)
+      rack (>= 1.4.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.2.1)
@@ -286,6 +288,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  heroku-deflater
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 Get a simple and fast local business website that updates itself
 with SEO-optimized content.
 
+## Project Status
+
+Kicksplash Sites is in the early stages of development. We're building the first version of the product and talking to potential customers.
+
+[See the current app in production](https://salty-wildwood-50450-0a6f756ece41.herokuapp.com/)
+
 ## The Problem
 
 Local businesses like residential contractors don't need much in terms of online marketing, and there are a ton of free and low-cost options for building and


### PR DESCRIPTION
[Link to Heroku app](https://salty-wildwood-50450-0a6f756ece41.herokuapp.com/)

The PageSpeed scores look similar to the scores for the Eleventy version hosted on Netlify. The remaining "opportunity" identified by PageSpeed Insights is to inline critical CSS, which doesn't make sense to tweak right now.