### PR TITLE
Bugfix: srcset error caused by bad picture element syntax

### DIFF
--- a/app/views/shared/_side_by_side.html.erb
+++ b/app/views/shared/_side_by_side.html.erb
@@ -7,10 +7,14 @@
         <!-- Left Image Section -->
         <div class="cs-left">
             <picture class="cs-picture cs-picture1">
-                <%= image_tag 'cabinets2.jpg', alt: 'cabinets', loading: 'lazy', decoding: 'async', width: 400, height: 563, srcset: { 'cabinets2-m.jpg': '(max-width: 600px)', 'cabinets2.jpg': '(min-width: 601px)' } %>
+                <%= tag.source media: '(max-width: 600px)', srcset: asset_path("cabinets2-m.jpg") %>
+                <%= tag.source media: '(min-width: 601px)', srcset: asset_path("cabinets2.jpg") %>
+                <%= image_tag "cabinets2.jpg", aria: { hidden: "true" }, decoding: "async", alt: "cabinets", loading: "lazy", width: 400, height: 563 %>
             </picture>
             <picture class="cs-picture cs-picture2">
-                <%= image_tag 'construction.jpg', alt: 'house', loading: 'lazy', decoding: 'async', width: 400, height: 563, srcset: { 'construction-m.jpg': '(max-width: 600px)', 'construction.jpg': '(min-width: 601px)' } %>
+                <%= tag.source media: '(max-width: 600px)', srcset: asset_path("construction-m.jpg") %>
+                <%= tag.source media: '(min-width: 601px)', srcset: asset_path("construction.jpg") %>
+                <%= image_tag "construction.jpg", aria: { hidden: "true" }, decoding: "async", alt: "house", loading: "lazy", width: 400, height: 563 %>
             </picture>
         </div>
         <!-- Right Content Section-->

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = "1.0"
+Rails.application.config.assets.version = "1.0.1"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path


### PR DESCRIPTION
Fixes a minor error seen in Dev tools:

```
Dropped srcset candidate "/assets/cabinets2-m-65979c91590285461d9174457ccdd0ca8bcf1fec45d4b0feb29146c6694caea0.jpg"
```